### PR TITLE
Fix stretched project images

### DIFF
--- a/style.scss
+++ b/style.scss
@@ -264,6 +264,10 @@ nav {
   margin-top: 20px;
 }
 
+.gallery figure img {
+  min-height: auto;
+}
+
 .text-center{
   text-align: center;
 }


### PR DESCRIPTION
They were stretched taller that their native aspect ratio. Now they look as pretty as they should 😄

Overriding what I assume is a default rule from the framework styles, hence the specific selector.